### PR TITLE
Feature/swap minumum output amount check

### DIFF
--- a/packages/deepbook-wrapper/sources/swap.move
+++ b/packages/deepbook-wrapper/sources/swap.move
@@ -7,7 +7,6 @@ use deepbook_wrapper::wrapper::{
     Wrapper,
     join_deep_reserves_coverage_fee,
     join,
-    get_deep_reserves_value,
     split_deep_reserves
 };
 use sui::clock::Clock;
@@ -49,8 +48,9 @@ public fun swap_exact_base_for_quote<BaseToken, QuoteToken>(
     let deep_payment = if (pool::whitelisted(pool)) {
         coin::zero(ctx)
     } else {
-        let deep_reserves_value = get_deep_reserves_value(wrapper);
-        split_deep_reserves(wrapper, deep_reserves_value, ctx)
+        let base_quantity = base_in.value();
+        let (_, _, deep_required) = pool.get_quote_quantity_out(base_quantity, clock);
+        split_deep_reserves(wrapper, deep_required, ctx)
     };
 
     // Execute swap through DeepBook's native swap function
@@ -108,8 +108,9 @@ public fun swap_exact_quote_for_base<BaseToken, QuoteToken>(
     let deep_payment = if (pool::whitelisted(pool)) {
         coin::zero(ctx)
     } else {
-        let deep_reserves_value = get_deep_reserves_value(wrapper);
-        split_deep_reserves(wrapper, deep_reserves_value, ctx)
+        let quote_quantity = quote_in.value();
+        let (_, _, deep_required) = pool.get_base_quantity_out(quote_quantity, clock);
+        split_deep_reserves(wrapper, deep_required, ctx)
     };
 
     // Execute swap through DeepBook's native swap function

--- a/packages/deepbook-wrapper/sources/swap.move
+++ b/packages/deepbook-wrapper/sources/swap.move
@@ -6,6 +6,7 @@ use deepbook_wrapper::helper::get_fee_bps;
 use deepbook_wrapper::wrapper::{
     Wrapper,
     join_deep_reserves_coverage_fee,
+    join_protocol_fee,
     join,
     split_deep_reserves
 };
@@ -64,7 +65,7 @@ public fun swap_exact_base_for_quote<BaseToken, QuoteToken>(
         ctx,
     );
 
-    // Apply wrapper protocol fees to the output
+    // Apply wrapper DEEP reserves coverage fees to the output
     let mut result_quote = quote_out;
     join(wrapper, deep_remainder);
 
@@ -124,7 +125,7 @@ public fun swap_exact_quote_for_base<BaseToken, QuoteToken>(
         ctx,
     );
 
-    // Apply wrapper protocol fees to the output
+    // Apply wrapper DEEP reserves coverage fees to the output
     let mut result_base = base_out;
     join(wrapper, deep_remainder);
 
@@ -181,7 +182,7 @@ public fun swap_exact_base_for_quote_input_fee<BaseToken, QuoteToken>(
     join(wrapper, deep_remainder);
 
     let fee_bps = get_fee_bps(pool);
-    join_deep_reserves_coverage_fee(wrapper, charge_swap_fee(&mut result_quote, fee_bps));
+    join_protocol_fee(wrapper, charge_swap_fee(&mut result_quote, fee_bps));
 
     // Verify that the final output after wrapper fees still meets the user's minimum requirement
     validate_minimum_output(&result_quote, min_quote_out);
@@ -233,7 +234,7 @@ public fun swap_exact_quote_for_base_input_fee<BaseToken, QuoteToken>(
     join(wrapper, deep_remainder);
 
     let fee_bps = get_fee_bps(pool);
-    join_deep_reserves_coverage_fee(wrapper, charge_swap_fee(&mut result_base, fee_bps));
+    join_protocol_fee(wrapper, charge_swap_fee(&mut result_base, fee_bps));
 
     // Verify that the final output after wrapper fees still meets the user's minimum requirement
     validate_minimum_output(&result_base, min_base_out);

--- a/packages/deepbook-wrapper/sources/swap.move
+++ b/packages/deepbook-wrapper/sources/swap.move
@@ -35,7 +35,8 @@ const EInsufficientOutputAmount: u64 = 1;
 /// 1. Handles DEEP payment for non-whitelisted pools
 /// 2. Executes swap through DeepBook
 /// 3. Processes wrapper fees
-/// 4. Returns remaining base and received quote tokens
+/// 4. Validates minimum output amount meets user requirements
+/// 5. Returns remaining base and received quote tokens
 public fun swap_exact_base_for_quote<BaseToken, QuoteToken>(
     wrapper: &mut Wrapper,
     pool: &mut Pool<BaseToken, QuoteToken>,
@@ -93,7 +94,8 @@ public fun swap_exact_base_for_quote<BaseToken, QuoteToken>(
 /// 1. Handles DEEP payment for non-whitelisted pools
 /// 2. Executes swap through DeepBook
 /// 3. Processes wrapper fees
-/// 4. Returns received base and remaining quote tokens
+/// 4. Validates minimum output amount meets user requirements
+/// 5. Returns received base and remaining quote tokens
 public fun swap_exact_quote_for_base<BaseToken, QuoteToken>(
     wrapper: &mut Wrapper,
     pool: &mut Pool<BaseToken, QuoteToken>,
@@ -151,7 +153,8 @@ public fun swap_exact_quote_for_base<BaseToken, QuoteToken>(
 /// # Flow
 /// 1. Executes swap through DeepBook
 /// 2. Processes wrapper fees
-/// 3. Returns remaining base and received quote tokens
+/// 3. Validates minimum output amount meets user requirements
+/// 4. Returns remaining base and received quote tokens
 public fun swap_exact_base_for_quote_input_fee<BaseToken, QuoteToken>(
     wrapper: &mut Wrapper,
     pool: &mut Pool<BaseToken, QuoteToken>,
@@ -202,7 +205,8 @@ public fun swap_exact_base_for_quote_input_fee<BaseToken, QuoteToken>(
 /// # Flow
 /// 1. Executes swap through DeepBook
 /// 2. Processes wrapper fees
-/// 3. Returns received base and remaining quote tokens
+/// 3. Validates minimum output amount meets user requirements
+/// 4. Returns received base and remaining quote tokens
 public fun swap_exact_quote_for_base_input_fee<BaseToken, QuoteToken>(
     wrapper: &mut Wrapper,
     pool: &mut Pool<BaseToken, QuoteToken>,

--- a/packages/deepbook-wrapper/sources/wrapper.move
+++ b/packages/deepbook-wrapper/sources/wrapper.move
@@ -31,6 +31,9 @@ public struct ChargedFeeKey<phantom CoinType> has copy, drop, store {
 #[error]
 const EInvalidFundCap: u64 = 1;
 
+/// Error when trying to use deep from reserves but there is not enough available
+const EInsufficientDeepReserves: u64 = 2;
+
 /// A generic error code for any function that is no longer supported.
 /// The value 1000 is used by convention across modules for this purpose.
 #[error]
@@ -152,6 +155,9 @@ public(package) fun split_deep_reserves(
     amount: u64,
     ctx: &mut TxContext,
 ): Coin<DEEP> {
+    let available_deep_reserves = wrapper.deep_reserves.value();
+    assert!(amount <= available_deep_reserves, EInsufficientDeepReserves);
+
     coin::from_balance(
         balance::split(&mut wrapper.deep_reserves, amount),
         ctx,


### PR DESCRIPTION
## Description

* Add validation to ensure swap output amounts after deducting wrapper fees meet user minimum requirements for output coin.
* Get from the wrapper reserves an exact `deep_required`, estimated by `get_quantity_out`, instead of providing to user the entire reserves for swap.
* Change destination for fees collected `swap_exact_quote_for_base_input_fee` and `swap_exact_base_for_quote_input_fee` from coverage to protocol.